### PR TITLE
Update example_export_form_data

### DIFF
--- a/examples/example_export_form_data.py
+++ b/examples/example_export_form_data.py
@@ -42,7 +42,7 @@ COUNT = FORM.get_count(start=START.timestamp(), end=END.timestamp())
 print(COUNT) # show count of form submits
 
 # Now export individual rows
-DATA = FORM.get_data(start=START.timestamp(), end=END.timestamp())
+DATA = FORM.get_data(start=int(START.timestamp()), end=int(END.timestamp()))
 
 # look at output form submissions
 for row in DATA:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '0.5.11'
+__version__ = '0.5.12'
 
 def readme():
     """ open readme for long_description """


### PR DESCRIPTION
There's a bug in the example as get_data() expects integers but `START.timestamp()` returns floats. This fix corrects it.